### PR TITLE
Fixed problem in linearCode(Matrix) constructor

### DIFF
--- a/CodingTheory/CodingTheory.m2
+++ b/CodingTheory/CodingTheory.m2
@@ -353,7 +353,7 @@ linearCode(Matrix) := LinearCode => opts -> M -> (
     
 
     if opts.ParityCheck then {
-	outputVec := {M.target, M.ring, {}, entries M, kernel M};
+	outputVec := {M.source, M.ring, {}, entries M, kernel M};
 	} else {
 	outputVec =  {M.source, M.ring, entries M, {}, image transpose M};
 	};

--- a/CodingTheory/CodingTheory.m2
+++ b/CodingTheory/CodingTheory.m2
@@ -224,7 +224,7 @@ rawLinearCode(List) := LinearCode => (inputVec) -> (
     
     
     -- check if "baseField" is a field, throw warning otherwise:
-    if not isField(inputVec_1) then print "Warning: Working over non-field.";
+    if not isField(inputVec_1) then print "Warning: Working over non-field.";    
    
     if inputVec_2 != {} then {
 	-- validate inputs and coerce into base field:
@@ -353,9 +353,9 @@ linearCode(Matrix) := LinearCode => opts -> M -> (
     
 
     if opts.ParityCheck then {
-	outputVec := {M.source, M.ring, {}, entries M, kernel M};
+	outputVec := {M.target, M.ring, {}, entries M, kernel M};
 	} else {
-	outputVec =  {M.target, M.ring, entries M, {}, image transpose M};
+	outputVec =  {M.source, M.ring, entries M, {}, image transpose M};
 	};
     
     rawLinearCode(outputVec)
@@ -511,13 +511,13 @@ HammingCode(ZZ,ZZ) := LinearCode => (q,r) -> (
     -- produce Hamming code
     -- q is the size of the field
     -- r is the dimension of the dual
-    K:=GF(q);
+    K := GF(q);
     -- setK is the set that contains all the elements of the field
-    setK:=set(  {0}| apply(toList(1..q-1),i -> K_1^i));
+    setK := set(  {0}| apply(toList(1..q-1),i -> K_1^i));
     -- C is the transpose of the parity check matrix of the code. Its rows are the the points of the
     -- projective space P(r-1,q)
-    j:=1;
-    C:= matrix(apply(toList(1..q^(r-j)), i -> apply(toList(1..1),j -> 1))) | matrix apply(toList(toList setK^**(r-j)/deepSplice),i->toList i);
+    j := 1;
+    C := matrix(apply(toList(1..q^(r-j)), i -> apply(toList(1..1),j -> 1))) | matrix apply(toList(toList setK^**(r-j)/deepSplice),i->toList i);
     for j from 2 to r do C=C|| matrix(apply(toList(1..q^(r-j)), i -> apply(toList(1..(j-1)),j -> 0))) | matrix(apply(toList(1..q^(r-j)), i -> apply(toList(1..1),j -> 1))) | matrix apply(toList(toList setK^**(r-j)/deepSplice),i->toList i);
 	
     -- The Hamming code is defined by its parity check matrix

--- a/CodingTheory/demo-code.m2
+++ b/CodingTheory/demo-code.m2
@@ -2,6 +2,57 @@ restart
 
 --Change your FileName to wherever your copy of the package lives:
 installPackage("CodingTheory", FileName => "/Users/gwynethwhieldon/M2develop/Workshop-2020-Cleveland/CodingTheory/CodingTheory.m2")
+check CodingTheory
+
+-- viewHelp("CodingTheory")
+
+
+
+-----------------------------------------------------
+-- Codes from Generator Matrices (as lists):
+-----------------------------------------------------
+F = GF(4)
+n = 7
+k = 3
+L = apply(toList(1..k),j-> apply(toList(1..n),i-> random(F)))
+C = linearCode(matrix(L))
+peek C
+
+
+for s in subsets(n) list apply(n, i -> if member(i,s) then 1 else 0)
+
+L
+
+peek C
+-- check that dimension and length are correct:
+dim C
+length C
+-- check that G*H^t = 0:
+C.GeneratorMatrix * (transpose C.ParityCheckMatrix)
+-----------------------------------------------------
+-- Codes from Parity Check Matrices (as a matrix):
+-----------------------------------------------------
+F = GF(2)
+L = {{1,0,1,0,0,0,1,1,0,0},{0,1,0,1,0,0,0,1,1,0},{0,0,1,0,1,0,0,0,1,1},{1,0,0,1,0,1,0,0,0,1},{0,1,0,0,1,1,1,0,0,0}}
+C = linearCode(F,L,ParityCheck => true)
+peek C
+
+incidenceMatrix(C.ParityCheckMatrix)
+
+
+
+
+-----------------------------------------------------
+-- Codes with Rank Deficient Matrices:
+-----------------------------------------------------
+R=GF 4
+M=R^4
+C = linearCode(R,{{1,0,1,0},{1,0,1,0}})
+peek C
+restart
+
+--Change your FileName to wherever your copy of the package lives:
+installPackage("CodingTheory", FileName => "/Users/gwynethwhieldon/M2develop/Workshop-2020-Cleveland/CodingTheory/CodingTheory.m2")
 viewHelp("CodingTheory")
 
 -----------------------------------------------------


### PR DESCRIPTION
Constructor linearCode(Matrix) swapped ambient module dimension with the code length in parity check and generator cases, caught by @henry-chimal and noted by @isoprou @hhlopez and @E-Camps . Update fixes error.