### PR TITLE
Integrated EvaluationCode.m2 into CodingTheory.m2

### DIFF
--- a/CodingTheory/CodingTheory.m2
+++ b/CodingTheory/CodingTheory.m2
@@ -14,8 +14,19 @@ newPackage(
 	AuxiliaryFiles => false, -- set to true if package comes with auxiliary files,
 	Configuration => {},
         DebuggingMode => false,
-	PackageImports => { },
-        PackageExports => {"Graphs"}
+	PackageImports => {
+	    "SRdeformations",
+	    "Polyhedra",
+	    "Graphs",
+	    "NAGtypes",
+	    "RationalPoints" },
+        PackageExports => {
+	    "SRdeformations",
+	    "Polyhedra",
+	    "Graphs",
+	    "NAGtypes",
+	    "RationalPoints" 
+	    }
 	)
 
 -- Any symbols or functions that the user is to have access to
@@ -27,11 +38,10 @@ export {
     "parityCheckToGenerator",
     "reduceMatrix",
     
+    -- Linear Code
     -- Types and Constructors
     "LinearCode",
     "linearCode",
-    "zeroCode",
-    "universeCode",
     "AmbientModule",
     "BaseField",
     "Generators",
@@ -41,7 +51,27 @@ export {
     "ParityCheckMatrix",
     "Code",
     
+    -- Evaluation Code
+    -- Types and Constructors
+    "EvaluationCode",
+    "VanishingIdeal",
+    "PolynomialSet",
+    "ExponentsMatrix",
+    "AmbientSpace",
+    "IncidenceMatrix",
+    "Sets",
+    "toricCode",
+    "evCodeGraph",
+    "codeGraph",
+    "codeGraphInc",
+    "cartesianCode",
+    "RMCode",
+    "orderCode",
+    
+    
     -- Families of Codes
+    "zeroCode",
+    "universeCode",
     "cyclicMatrix",
     "quasiCyclicCode",
     "HammingCode",
@@ -85,7 +115,7 @@ exportMutable {}
 
 ------------------------------------------
 ------------------------------------------
--- Data Types and Constructors
+-- Linear Code Data Types and Constructors
 ------------------------------------------
 ------------------------------------------
 
@@ -210,8 +240,9 @@ wellDefinedInput(List) :=  UserInput -> (
   )
 
 
-
-
+------------------------------------------
+-- Linear Code Type and constructors:
+------------------------------------------
 
 -- Use this section to add basic types and
 -- constructors for error correcting codes
@@ -368,6 +399,314 @@ net LinearCode := c -> (
      "Code with Generator Matrix: " | net c.GeneratorMatrix
      )
 toString LinearCode := c -> toString c.Generators
+
+-----------------------------------------------
+-----------------------------------------------
+-- Evaluation Code Data Types and Constructors
+-----------------------------------------------
+-----------------------------------------------
+
+-*
+    new EvaluationCode from{
+	symbol Points => P, --- the points of (F*)^m
+	symbol VanishingIdeal => I, --the vanishing ideal of (F*)^m
+	symbol ExponentsMatrix => LL, -- the matrix of exponents, exponent vectors are rows
+	symbol IncidenceMatrix => M,
+	symbol PolynomialSet => S,
+	symbol LinearCode => linearCode(G), -- the linear code
+	symbol Sets => S,
+	symbol AmbientSpace => F^(#P),
+	symbol cache => {}
+	}
+*-
+
+EvaluationCode = new Type of HashTable
+
+evaluationCode = method(Options => {})
+
+evaluationCode(Ring,List,List) := EvaluationCode => opts -> (F,P,S) -> (
+    -- constructor for the evaluation code
+    -- input: a field, a list of points, a set of polynomials.
+    -- outputs: The list of points, the list of polynomials, the vanishing ideal and the linear code.
+    
+    R := ring S#0;
+
+    I := intersect apply(P,i->ideal apply(numgens R,j->R_j-i#j)); -- Vanishing ideal of the set of points.
+
+    G := transpose matrix apply(P,i->flatten entries sub(matrix(R,{S}),matrix(F,{i}))); -- Evaluate the elements in S over the elements on P.
+    
+    return new EvaluationCode from{
+	symbol VanishingIdeal => I,
+	symbol Points => P,
+	symbol PolynomialSet => S,
+	symbol LinearCode => linearCode G,
+	symbol cache => {}
+	}
+    )
+
+evaluationCode(Ring,List,Matrix) := EvaluationCode => opts -> (F,P,M) -> (
+    -- Constructor for a evaluation (monomial) code.
+    -- inputs: a field, a list of points (as a tuples) of the same length and a matrix of exponents.
+    -- outputs: a F-module.
+    
+    -- We should check if all the points of P are in the same F-vector space.
+
+    m := numgens image M; -- number of monomials.
+    
+    t := getSymbol "t";
+
+    R := F[t_0..t_(m-1)];
+
+    S := apply(entries M, i -> vectorToMonomial(vector i,R));
+    
+    evaluationCode(F,P,S)
+    )
+
+net EvaluationCode := c -> (
+    c.LinearCode
+    )
+
+------------------------------------------
+-- Evaluation Code constructors:
+------------------------------------------
+
+   
+toricCode = method(Options => {})
+
+toricCode(Ring,Matrix) := EvaluationCode => opts -> (F,M) -> (
+    -- Constructor for a toric code.
+    -- inputs: a Galois field, an integer matrix 
+    -- outputs: the evaluation code defined by evaluating all monomials corresponding to integer 
+    ---         points in the convex hull (lattice polytope) of the columns of M at the points of the algebraic torus (F*)^n
+    
+    z:=F_0;  --- define the primitive element of the field
+    q:=F.order; --- define the size of the field
+    s:=set apply(q-1,i->z^i); -- set of non-zero elements in the field
+    m:=numgens target M; --- the length of the exponent vectors, i.e. number of variables for monomials, i.e.the dim of the ambient space containing the polytope
+    ss:=s; 
+    for i from 1 to m-1 do (
+    	ss=set toList ss/splice**s;  
+    );
+    P:=toList ss/splice;   -- the loop above creates the list of all m-tuples of non-zero elements of F, i.e. the list of points in the algebraic torus (F*)^m
+    Polytop:=convexHull M; -- the convex hull of the columns of M
+    L:=latticePoints Polytop; -- the list of lattice points in Polytop
+    LL:=matrix apply(L, i-> first entries transpose i); --converts the list of lattice points to a matrix of exponents
+    G:=matrix apply(entries LL,i->apply(P,j->product apply(m,k->(j#k)^(i#k)))); -- the matrix of generators; rows form a generating set of codewords
+    
+    t := getSymbol t;
+    
+    R:=F[t_1..t_m]; --- defines the ring containing monomials corresponding to exponents
+    I := ideal apply(m,j->R_j^(q-1)-1); --  the vanishing ideal of (F*)^m
+    
+    new EvaluationCode from{
+	symbol Points => P, --- the points of (F*)^m
+	symbol VanishingIdeal => I, --the vanishing ideal of (F*)^m
+	symbol ExponentsMatrix => LL, -- the matrix of exponents, exponent vectors are rows
+	symbol LinearCode => linearCode(G), -- the linear code
+	symbol cache => {}
+	}
+) 
+
+----------Reed–Muller-type code of degree d over a graph using our the algorithm of evaluationCode
+evCodeGraph  = method(Options => {});
+
+evCodeGraph (Ring,Matrix,List) := evCodeGraph  => opts -> (F,M,S) -> (
+    -- input: a field, Incidence matrix of the graph , a set of polynomials.
+    -- outputs: a monomial code over the list of points.
+    
+    -- We should check if all the points lives in the same F-vector space.
+    -- Should we check if all the monomials lives in the same ring?
+    
+    P := entries transpose M;
+ 
+    R := ring S#0;
+
+    I := intersect apply(P,i->ideal apply(numgens R-1,j->R_j-i#j)); -- Vanishing ideal of the set of points.
+
+    S = toList apply(apply(S,i->promote(i,R/I)),j->lift(j,R))-set{0*S#0}; -- Drop the elements in S that was already in I.
+
+    G := matrix apply(P,i->flatten entries sub(matrix(R,{S}),matrix(F,{i}))); -- Evaluate the elements in S over the elements on P.
+    
+    
+    new EvaluationCode from{
+	symbol AmbientSpace => F^(#P),
+	symbol Points => P,
+	symbol VanishingIdeal => I,
+	symbol PolynomialSet => S,
+	symbol LinearCode => linearCode(G),
+	symbol cache => {}
+	}
+    )
+
+
+-------Reed–Muller-type code of degree d over a graph using the function evaluate from package "NAGtypes"---------------
+
+
+codeGraph  = method(TypicalValue => Module);
+
+codeGraph (Matrix,ZZ,ZZ) := (M,d,p)->(
+    K:=ZZ/p;
+    tMatInc:=transpose M;
+    X:=entries tMatInc;
+    
+    t := getSymbol "t";
+    R:=K[t_(0)..t_(numgens target M-1)];
+    
+    SetPoly:=flatten entries basis(d,R);
+    SetPolySys:=apply(0..length SetPoly-1, x->polySystem{SetPoly#x});
+    XX:=apply(X,x->point{x});
+    C:=apply(apply(SetPolySys,y->apply(0..length XX -1,x->(flatten entries evaluate(y,XX#x))#0)),toList);
+    G:=transpose matrix{C};
+    
+    new EvaluationCode from{
+	symbol AmbientSpace => K^(#X),
+	symbol IncidenceMatrix => M,
+	symbol LinearCode => linearCode(G),
+	symbol cache => {}
+	}
+    
+)
+
+
+codeGraphInc = method(TypicalValue => Module);
+-- M is the incidence matrix of the Graph G
+--inputs: The incidence matrix of a Graph G, a prime number  
+-- outputs: K-module
+
+codeGraphInc (Matrix,ZZ):= (M,p)->(
+    K:=ZZ/p;
+    tInc:=transpose M;
+    X:=entries tInc;
+    
+    t := getSymbol "t";
+    R:=K[t_(0)..t_(numgens target M-1)];
+    
+    SetPol:=flatten entries basis(1,R);
+    SetPolSys:=apply(0..length SetPol-1, x->polySystem{SetPol#x});
+    XX:=apply(X,x->point{x});
+    C:=apply(apply(SetPolSys,y->apply(0..length XX -1,x->(flatten entries evaluate(y,XX#x))#0)),toList);
+    G:=transpose matrix{C};
+
+    new EvaluationCode from{
+	symbol AmbientSpace => K^(#X),
+	symbol IncidenceMatrix => M,
+	symbol LinearCode => linearCode(G),
+	symbol cache => {}
+	}
+)
+
+
+cartesianCode = method(Options => {})
+
+cartesianCode(Ring,List,List) := EvaluationCode => opts -> (F,S,M) -> (
+    --constructor for a cartesian code
+    --input: a field, a list of subsets of F and a list of polynomials.
+    --outputs: The evaluation code using the cartesian product of the elements in S and the polynomials in M.
+    
+    m := #S;
+    R := ring M#0;
+    I := ideal apply(m,i->product apply(S#i,j->R_i-j));
+    P := set S#0;
+    for i from 1 to m-1 do P=P**set S#i;
+    P = apply(toList(P/deepSplice),i->toList i);
+    G := transpose matrix apply(P,i->flatten entries sub(matrix(R,{M}),matrix(F,{i})));
+    
+    new EvaluationCode from{
+	symbol Sets => S,
+	symbol VanishingIdeal => I,
+	symbol PolynomialSet => M,
+	symbol LinearCode => linearCode(G),
+	symbol cache => {}
+	}
+    )
+
+cartesianCode(Ring,List,ZZ) := EvaluationCode => opts -> (F,S,d) -> (
+    -- Constructor for cartesian codes.
+    -- inputs: A field F, a set of tuples representing the subsets of F and the degree d.
+    -- outputs: the cartesian code of degree d.
+    m:=#S;
+    
+    t := getSymbol "t";
+    R:=F[t_0..t_(m-1)];
+    M:=apply(flatten entries basis(R/monomialIdeal basis(d+1,R)),i->lift(i,R));
+    
+    cartesianCode(F,S,M)
+    )
+   
+cartesianCode(Ring,List,Matrix) := EvaluationCode => opts -> (F,S,M) -> (
+    -- constructor for a monomial cartesian code.
+    -- inputs: a field, a list of sets, a matrix representing as rows the exponents of the variables
+    -- outputs: a cartesian code evaluated with monomials
+    
+    -- Should we add a second version of this function with a third argument an ideal? For the case of decreasing monomial codes.
+    
+    m := #S;
+    
+    t := getSymbol "t";
+    R := F[t_0..t_(m-1)];
+    T := apply(entries M,i->vectorToMonomial(vector i,R));
+    
+    cartesianCode(F,S,T)
+    )
+
+
+RMCode = method(TypicalValue => EvaluationCode)
+    
+RMCode(ZZ,ZZ,ZZ) := EvaluationCode => (q,m,d) -> (
+    -- Contructor for a generalized Reed-Muller code.
+    -- Inputs: A prime power q (the order of the finite field), m the number of variables in the defining ring  and an integer d (the degree of the code).
+    -- outputs: The cartesian code of the GRM code.
+    
+    F := GF(q);
+    S := apply(q-1, i->F_0^i)|{0*F_0};
+    S = apply(m, i->S);
+    
+    cartesianCode(F,S,d)
+    )
+
+
+orderCode = method(Options => {})
+
+orderCode(Ring,List,List,ZZ) := EvaluationCode => opts -> (F,G,P,l) -> (
+    -- Order codes are defined through a set of points and a numerical semigroup.
+    -- Inputs: A field, a list of points P, the minimal generating set of the semigroup (where G_1<G_2<...) of the order function, a bound l.
+    -- Outputs: the evaluation code evaluated in P by the polynomials with weight less or equal than l.
+    
+    -- We should add a check to way if all the points are of the same length.
+    
+    m := length P#0;
+    
+    t := getSymbol "t";
+    R := F[t_0..t_(m-1), Degrees=>G];
+    M := matrix apply(toList sum apply(l+1, i -> set flatten entries basis(i,R)),j->first exponents j);
+    
+    evaluationCode(F,P,M)
+    )
+
+orderCode(Ideal,List,List,ZZ) := EvaluationCode => opts -> (I,P,G,l) -> (
+    -- If we know the defining ideal of the finite algebra associated to the order function, we can obtain the generating matrix.
+    -- Inputs: The ideal I that defines the finite algebra of the order function, the points to evaluate over, the minimal generating set of the semigroups associated to the order function and the bound.
+    -- Outpus: an evaluation code.
+    
+    m := #flatten entries basis(1,I.ring);
+    
+    t := getSymbol "t";
+    R := (coefficientRing I.ring)[t_1..t_m, Degrees=>G, MonomialOrder => (reverse apply(flatten entries basis(1,I.ring),i -> Weights => first exponents i))];
+    J := sub(I,matrix{gens R});
+    S := R/J;
+    M := matrix apply(toList sum apply(l+1,i->set flatten entries basis(i,S)),i->first exponents i);
+    
+    evaluationCode(coefficientRing I.ring, P, M)
+    )
+
+orderCode(Ideal,List,ZZ) := EvaluationCode => opts -> (I,G,l) -> (
+    -- The same as before, but taking P as the rational points of I.
+    
+    P := rationalPoints I;
+    orderCode(I,P,G,l)
+    )
+
+
 
 ------------------------------------------
 ------------------------------------------
@@ -675,11 +1014,9 @@ getGroupAnnihilatorPolynomial(List,ZZ) := RingElement => (G,q) -> (
 
 
 
-
-
 ------------------------------------------
 ------------------------------------------
--- Methods
+-- Linear Code Methods
 ------------------------------------------
 ------------------------------------------
 
@@ -1024,6 +1361,12 @@ tannerGraph(Matrix) := H -> (
 ------------------------------------------
 ------------------------------------------
 
+-----------------------------------------------
+-----------------------------------------------
+-- Use this section for LinearCode tests:
+-----------------------------------------------
+-----------------------------------------------
+
 TEST ///
 -- tannerGraph test
 R := GF(2);
@@ -1179,6 +1522,13 @@ C2= HammingCode(2,4)
 assert( length C2 == 15)
 ///
 
+-----------------------------------------------
+-----------------------------------------------
+-- Use this section for Evaluation Code Tests
+-----------------------------------------------
+-----------------------------------------------
+
+
 
 ------------------------------------------
 ------------------------------------------
@@ -1216,6 +1566,12 @@ document {
 	}
     	
 	}
+    
+-----------------------------------------------
+-----------------------------------------------
+-- Use this section for Linear Code documentation:
+-----------------------------------------------
+-----------------------------------------------
     
 document {
     Key => {linearCode, (linearCode,Module), (linearCode,GaloisField,List), (linearCode,Module,List)},
@@ -1488,7 +1844,19 @@ document {
 	}
  }
 
+
+-----------------------------------------------
+-----------------------------------------------
+-- Use this section for Evaluation Code documentation:
+-----------------------------------------------
+-----------------------------------------------
+
  
+       
+       
+       
+       
+       
        
 end
 


### PR DESCRIPTION
Integrated EvaluationCode types and basic constructors into CodingTheory package, exported all appropriate packages and symbols. After this pull request is accepted, planning to merge this with master.

There's still some work to be done to make the key structure of EvaluationCode consistent across all the constructors. Currently this would be the "overall" key structure of an EvaluationCode in it's current format:
```
new EvaluationCode from{
	symbol Points => P, 
	symbol VanishingIdeal => I, 
	symbol ExponentsMatrix => LL,
	symbol IncidenceMatrix => M,
	symbol PolynomialSet => S,
	symbol LinearCode => linearCode(G),
	symbol Sets => S,
	symbol AmbientSpace => F^(#P),
	symbol cache => {}
	}
```
Eventually, this list may be shorter (or slightly different). Not all evaluationCode constructors produce the same subset of these keys -- but the package at least will install and has all checks run successfully.